### PR TITLE
ClientQuoteCard Comp

### DIFF
--- a/public/data/driversDetail/driversDetailData.json
+++ b/public/data/driversDetail/driversDetailData.json
@@ -3,8 +3,8 @@
   "image": "http://placehold.it/56x56",
   "name": "홍길동",
   "introduce": "5년 경력의 신뢰할 수 있는 기사입니다.",
-  "favoriteCount": 5,
-  "score": 4.8,
+  "likeCount": 5,
+  "rating": 4.8,
   "career": 9,
   "applyCount": 10,
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 // const BASE_URL = 'http://localhost:3000';
-// const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export async function fetchWrapper(url: string, options: RequestInit = {}) {
   const headers = {

--- a/src/components/cards/ClientQuoteCard.tsx
+++ b/src/components/cards/ClientQuoteCard.tsx
@@ -1,11 +1,8 @@
-'use client';
-
-import type { ManageQuotationCardProps } from '@/interfaces/Card/ManageQuotationCardInterface';
-import AddressFormat, { DateFormat, priceFormat, timeAgoFormat } from '@/utils/Format';
+import type { ClientQuoteCardProps } from '@/interfaces/Card/ClientQuoteCardInterface';
+import AddressFormat, { DateFormat, timeAgoFormat } from '@/utils/Format';
 import MovingTypeChips from '../chips/MovingTypeChips';
-import { ButtonWrapper } from '../common/headless/Button';
 
-export default function ManageQuotationCard({ data }: ManageQuotationCardProps) {
+export default function ClientQuoteCard({ data }: ClientQuoteCardProps) {
   // TODO: api 연결 시 변경되는 데이터 값에 관해서는 수정 예정입니다.
   // let status: string = 'end';
   let status: string = 'abandon';

--- a/src/components/cards/ClientQuoteCard.tsx
+++ b/src/components/cards/ClientQuoteCard.tsx
@@ -3,23 +3,24 @@ import AddressFormat, { DateFormat, timeAgoFormat } from '@/utils/Format';
 import MovingTypeChips from '../chips/MovingTypeChips';
 
 export default function ClientQuoteCard({ data }: ClientQuoteCardProps) {
-  // TODO: api 연결 시 변경되는 데이터 값에 관해서는 수정 예정입니다.
+  // Api 연결 필요
   // let status: string = 'end';
-  let status: string = 'abandon';
+  // let status: string = 'abandon';
+
   return (
     <>
-      <div className="relative w-full rounded-[1.6rem] border border-line-100 lg:pt-[2rem] lg:pb-[1.2rem] lg:px-[2.4rem] sm:py-[1.6rem] sm:px-[1.4rem] flex flex-col lg:gap-[1.6rem] sm:gap-[2.6rem] shadow-[0.2rem_-0.2rem_1rem_rgba(220,220,220,0.14)]">
+      <div className="relative w-full rounded-[1.6rem] border border-line-100 lg:pt-[2rem] lg:pb-[1.2rem] lg:px-[2.4rem] md:p-[1.6rem] sm:py-[1.6rem] sm:px-[1.4rem] shadow-custom9">
         <div className="flex flex-col gap-[1.6rem]">
-          <div className="flex justify-between">
-            <div className="flex gap-[1.2rem] items-center">
+          <div className="flex justify-between items-center">
+            <div className="flex lg:gap-[1.2rem] sm:gap-[0.8rem]">
               {/* 견적 확정시에만 RECEIVED 띄우기 */}
               <MovingTypeChips type="RECEIVED" />
               <MovingTypeChips type={data.moveInfo.type} />
             </div>
             <p className="font-normal text-[1.2rem] leading-[1.8rem] text-gray-500">{timeAgoFormat(data.updatedAt)}</p>
           </div>
-          <div className="lg:py-[1.6rem] flex flex-col lg:gap-[1.8rem] sm:gap-[1rem]">
-            <div className="md:block sm:flex flex-col gap-[1.4rem]">
+          <div className="md:py-[1.6rem] flex flex-col lg:gap-[1.8rem] md:gap-[1.6rem] sm:gap-[1.4rem]">
+            <div className="sm:flex flex-col gap-[1.4rem]">
               <p className="font-semibold lg:text-[2rem] sm:text-[1.6rem] lg:leading-[3.2rem] sm:leading-[2.6rem] text-black-300">
                 {data.moveInfo.owner} 고객님
               </p>
@@ -38,13 +39,13 @@ export default function ClientQuoteCard({ data }: ClientQuoteCardProps) {
             <div className="flex lg:gap-[1.6rem] sm:gap-[1.4rem] items-center">
               <div className="md:block sm:hidden">
                 <div className="flex items-center gap-[1.2rem]">
-                  <p className="rounded-[0.4rem] py-[0.4rem] px-[0.6rem] bg-background-400 font-normal text-[1.55rem] leading-[2.6rem] text-gray-500">
+                  <p className="rounded-[0.4rem] lg:py-[0.4rem] sm:py-[0.2rem] px-[0.6rem] bg-background-400 font-normal text-[1.55rem] leading-[2.6rem] text-gray-500">
                     이사일
                   </p>
                   <p className="font-medium text-[1.55rem] leading-[2.6rem] text-black-300">{DateFormat(data.moveInfo.date)}</p>
                 </div>
               </div>
-              <div className="h-[1.4rem] border border-line-200 md:block sm:hidden" />
+              <div className="lg:h-[1.6rem] sm:h-[1.4rem] border border-line-200 md:block sm:hidden" />
               <div className="flex items-center gap-[1.2rem]">
                 <p className="rounded-[0.4rem] lg:py-[0.4rem] sm:py-[0.2rem] px-[0.6rem] bg-background-400 font-normal lg:text-[1.55rem] sm:text-[1.4rem] lg:leading-[2.6rem] sm:leading-[2.4rem] text-gray-500">
                   출발
@@ -53,7 +54,7 @@ export default function ClientQuoteCard({ data }: ClientQuoteCardProps) {
                   {AddressFormat(data.moveInfo.fromAddress)}
                 </p>
               </div>
-              <div className="h-[1.4rem] border border-line-200" />
+              <div className="lg:h-[1.6rem] sm:h-[1.4rem] border border-line-200" />
               <div className="flex items-center gap-[1.2rem]">
                 <p className="rounded-[0.4rem] lg:py-[0.4rem] sm:py-[0.2rem] px-[0.6rem] bg-background-400 font-normal lg:text-[1.55rem] sm:text-[1.4rem] lg:leading-[2.6rem] sm:leading-[2.4rem] text-gray-500">
                   도착

--- a/src/components/cards/ClientQuoteCard.tsx
+++ b/src/components/cards/ClientQuoteCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { ManageQuotationCardProps } from '@/interfaces/Card/ManageQuotationCardInterface';
+import AddressFormat, { DateFormat, priceFormat, timeAgoFormat } from '@/utils/Format';
+import MovingTypeChips from '../chips/MovingTypeChips';
+import { ButtonWrapper } from '../common/headless/Button';
+
+export default function ManageQuotationCard({ data }: ManageQuotationCardProps) {
+  // TODO: api 연결 시 변경되는 데이터 값에 관해서는 수정 예정입니다.
+  // let status: string = 'end';
+  let status: string = 'abandon';
+  return (
+    <>
+      <div className="relative w-full rounded-[1.6rem] border border-line-100 lg:pt-[2rem] lg:pb-[1.2rem] lg:px-[2.4rem] sm:py-[1.6rem] sm:px-[1.4rem] flex flex-col lg:gap-[1.6rem] sm:gap-[2.6rem] shadow-[0.2rem_-0.2rem_1rem_rgba(220,220,220,0.14)]">
+        <div className="flex flex-col gap-[1.6rem]">
+          <div className="flex justify-between">
+            <div className="flex gap-[1.2rem] items-center">
+              {/* 견적 확정시에만 RECEIVED 띄우기 */}
+              <MovingTypeChips type="RECEIVED" />
+              <MovingTypeChips type={data.moveInfo.type} />
+            </div>
+            <p className="font-normal text-[1.2rem] leading-[1.8rem] text-gray-500">{timeAgoFormat(data.updatedAt)}</p>
+          </div>
+          <div className="lg:py-[1.6rem] flex flex-col lg:gap-[1.8rem] sm:gap-[1rem]">
+            <div className="md:block sm:flex flex-col gap-[1.4rem]">
+              <p className="font-semibold lg:text-[2rem] sm:text-[1.6rem] lg:leading-[3.2rem] sm:leading-[2.6rem] text-black-300">
+                {data.moveInfo.owner} 고객님
+              </p>
+              <div className="md:hidden sm:block">
+                <div className="flex items-center gap-[1.2rem]">
+                  <p className="rounded-[0.4rem] lg:py-[0.4rem] sm:py-[0.2rem] px-[0.6rem] bg-background-400 font-normal lg:text-[1.6rem] sm:text-[1.4rem] lg:leading-[2.6rem] sm:leading-[2.4rem] text-gray-500">
+                    이사일
+                  </p>
+                  <p className="font-medium lg:text-[1.6rem] lg:leading-[2.6rem] sm:text-[1.4rem] sm:leading-[2.4rem] text-black-300">
+                    {DateFormat(data.moveInfo.date)}
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="w-full border border-line-100" />
+            <div className="flex lg:gap-[1.6rem] sm:gap-[1.4rem] items-center">
+              <div className="md:block sm:hidden">
+                <div className="flex items-center gap-[1.2rem]">
+                  <p className="rounded-[0.4rem] py-[0.4rem] px-[0.6rem] bg-background-400 font-normal text-[1.55rem] leading-[2.6rem] text-gray-500">
+                    이사일
+                  </p>
+                  <p className="font-medium text-[1.55rem] leading-[2.6rem] text-black-300">{DateFormat(data.moveInfo.date)}</p>
+                </div>
+              </div>
+              <div className="h-[1.4rem] border border-line-200 md:block sm:hidden" />
+              <div className="flex items-center gap-[1.2rem]">
+                <p className="rounded-[0.4rem] lg:py-[0.4rem] sm:py-[0.2rem] px-[0.6rem] bg-background-400 font-normal lg:text-[1.55rem] sm:text-[1.4rem] lg:leading-[2.6rem] sm:leading-[2.4rem] text-gray-500">
+                  출발
+                </p>
+                <p className="font-medium lg:text-[1.55rem] lg:leading-[2.6rem] sm:text-[1.4rem] sm:leading-[2.4rem] text-black-300">
+                  {AddressFormat(data.moveInfo.fromAddress)}
+                </p>
+              </div>
+              <div className="h-[1.4rem] border border-line-200" />
+              <div className="flex items-center gap-[1.2rem]">
+                <p className="rounded-[0.4rem] lg:py-[0.4rem] sm:py-[0.2rem] px-[0.6rem] bg-background-400 font-normal lg:text-[1.55rem] sm:text-[1.4rem] lg:leading-[2.6rem] sm:leading-[2.4rem] text-gray-500">
+                  도착
+                </p>
+                <p className="font-medium lg:text-[1.55rem] lg:leading-[2.6rem] sm:text-[1.4rem] sm:leading-[2.4rem] text-black-300">
+                  {AddressFormat(data.moveInfo.toAddress)}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/interfaces/Card/ClientQuoteCardInterface.ts
+++ b/src/interfaces/Card/ClientQuoteCardInterface.ts
@@ -1,0 +1,17 @@
+export interface ClientQuoteCardProps {
+  data: {
+    id: string;
+    updatedAt: string;
+    price: number;
+    moveInfo: {
+      id: string;
+      updatedAt: string;
+      type: 'SMALL' | 'HOME' | 'OFFICE' | 'APPOINTMENT';
+      date: string;
+      fromAddress: string;
+      toAddress: string;
+      progress: string;
+      owner: string;
+    };
+  };
+}

--- a/src/stories/ClientQuoteCard.stories.tsx
+++ b/src/stories/ClientQuoteCard.stories.tsx
@@ -1,0 +1,29 @@
+import type { StoryFn } from '@storybook/react';
+import ClientQuoteCard from '@/components/cards/ClientQuoteCard';
+import type { ClientQuoteCardProps } from '@/interfaces/Card/ClientQuoteCardInterface';
+
+export default {
+  title: 'Components/Cards/ClientQuoteCard',
+  component: ClientQuoteCard,
+};
+
+const Template: StoryFn<ClientQuoteCardProps> = args => <ClientQuoteCard {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  data: {
+    id: 'estimation-1',
+    updatedAt: '2025-01-01T12:00:00Z',
+    price: 200000,
+    moveInfo: {
+      id: 'moveinfo-1',
+      updatedAt: '2025-01-01T12:00:00Z',
+      type: 'HOME',
+      date: '2025-02-01T12:00:00Z',
+      fromAddress: '서울 중구 삼일대로 343',
+      toAddress: '서울 중구 청계천로 100',
+      progress: 'PENDING',
+      owner: '김재원',
+    },
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,6 +56,7 @@ const config: Config = {
         custom6: '4px 4px 10px rgba(195, 217, 242, 0.2)',
         custom7: '0 2px 10px rgba(248, 248, 248, 0.1)',
         custom8: '0px 4px 8px rgba(0, 0, 0, 0.16)',
+        custom9: '2px 2px 10px 0px rgba(220, 220, 220, 0.1), -2px -2px 10px 0px rgba(220, 220, 220, 0.1)',
         customBoth: '4px 4px 10px 0px rgba(225, 225, 225, 0.102), inset 6px 6px 10px 0px rgba(244, 244, 244, 0.2)',
         chipServiceShadow: '4px 4px 10px 0px rgba(230, 230, 230, 0.25)',
         chipAreaShadow: '4px 4px 10px 0px rgba(230, 230, 230, 0.161)',


### PR DESCRIPTION
## 이슈 번호

- close #124

## 작업 사항
- [x] 고객 견적 카드 컴포넌트
- [x] 스토리북 테스트

## 기타
### 받았던 견적 상세 페이지
- 들어오는 데이터에 따라 "확정 견적" 칩 or X
- 확정 견적 X -> 토스트 창 아직 X

### 기사님 상세 페이지
- 찜하기, 지정 견적 요청 등 회원 비회원 페이지 기능 나누기
- [review 부분] 피그마에서 유저 name에 별표로 이름을 가려주는 부분이 있는데, 나중에 api 연결하고 완성되면 어떤 식으로 처리해줄지 상의해보면 좋을 것 같습니다
- pagination 기능은 백엔드 API 연결 후 확인 가능 (현재 불가)

### 상세 페이지 공통
- get Data API 연결하기
- 공유하기 기능 만들기 (링크, 카카오톡, 페이스북)
- ButtonClient API 연결하기
