### PR TITLE
Toast on QuoteReceivedDetail

### DIFF
--- a/public/assets/toast/ic_blue_info.svg
+++ b/public/assets/toast/ic_blue_info.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_7603)">
+<circle cx="12" cy="12" r="11.5" fill="#F5FAFF" stroke="#4DA9FF"/>
+<rect x="11" y="6" width="2" height="8" fill="#4DA9FF"/>
+<circle cx="12" cy="17" r="1" fill="#4DA9FF"/>
+</g>
+<defs>
+<clipPath id="clip0_1_7603">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/normal/my-quote/received/[id]/page.tsx
+++ b/src/app/normal/my-quote/received/[id]/page.tsx
@@ -6,6 +6,7 @@ import kakao from '@/../../public/assets/driver/ic_kakao.svg';
 import { getEstimationData } from '@/api/DriverService';
 import EstimationInformationCard from '@/components/cards/EstimateInformationCard';
 import FindDriverCard from '@/components/cards/FindDriverCard';
+import MyQuoteReceivedToast from '@/components/toasts/MyQuoteReceivedToast';
 import DetailButtonClient from '@/pages/DriverDetail/DetailButtonClient';
 import { priceFormat } from '@/utils/Format';
 
@@ -59,7 +60,12 @@ export default async function MyQuoteReceivedDetail({ params }: { params: { id: 
             </p>
           </div>
           <div className="border border-line-100 w-full"></div>
-          <EstimationInformationCard data={quoteData} />
+          <div className="flex flex-col lg:gap-[2.2rem] sm:gap-[0.8rem]">
+            <EstimationInformationCard data={quoteData} />
+            {/* 확정 견적이 아닐 때 토스트 창 띄우기 사용 */}
+            {/* 현재는 모든 페이지에 토스트 띄워져 있는 상태 */}
+            <MyQuoteReceivedToast />
+          </div>
         </div>
         <div className="lg:block sm:hidden">
           <div className="flex flex-col w-[32.8rem] gap-[4rem]">
@@ -78,8 +84,6 @@ export default async function MyQuoteReceivedDetail({ params }: { params: { id: 
           </div>
         </div>
       </div>
-      {/* 확정 견적이 아닐 때 토스트 창 띄우기 사용 */}
-      {/* 현재는 모든 페이지에 토스트 띄워져 있는 상태 */}
       <div className="lg:hidden sm:block">
         <div className="fixed py-[1rem] bottom-0 left-0 w-full shadow-custom8 bg-white flex items-center justify-center">
           <div className="flex flex-row gap-[0.8rem] md:w-[60rem] sm:w-[32.7rem] justify-center">

--- a/src/app/normal/my-quote/received/[id]/page.tsx
+++ b/src/app/normal/my-quote/received/[id]/page.tsx
@@ -78,6 +78,8 @@ export default async function MyQuoteReceivedDetail({ params }: { params: { id: 
           </div>
         </div>
       </div>
+      {/* 확정 견적이 아닐 때 토스트 창 띄우기 사용 */}
+      {/* 현재는 모든 페이지에 토스트 띄워져 있는 상태 */}
       <div className="lg:hidden sm:block">
         <div className="fixed py-[1rem] bottom-0 left-0 w-full shadow-custom8 bg-white flex items-center justify-center">
           <div className="flex flex-row gap-[0.8rem] md:w-[60rem] sm:w-[32.7rem] justify-center">

--- a/src/components/toasts/MyQuoteReceivedToast.tsx
+++ b/src/components/toasts/MyQuoteReceivedToast.tsx
@@ -1,0 +1,13 @@
+import Image from 'next/image';
+import info from '@/../public/assets/toast/ic_blue_info.svg';
+
+export default function MyQuoteReceivedToast() {
+  return (
+    <div className="w-full rounded-[1.2rem] border border-blue-200 lg:gap-[1.6rem] sm:gap-[0.8rem] lg:py-[2.4rem] lg:px-[3.2rem] sm:py-[1rem] sm:px-[2.4rem] flex items-center bg-blue-100">
+      <Image src={info} alt="info" width={24} height={24} />
+      <p className="font-semibold lg:text-[1.6rem] lg:leading-[2.6rem] sm:text-[1.3rem] sm:leading-[2.2rem] text-blue-300">
+        확정하지 않은 견적이에요!
+      </p>
+    </div>
+  );
+}

--- a/src/components/toasts/MyQuoteReceivedToast.tsx
+++ b/src/components/toasts/MyQuoteReceivedToast.tsx
@@ -3,7 +3,7 @@ import info from '@/../public/assets/toast/ic_blue_info.svg';
 
 export default function MyQuoteReceivedToast() {
   return (
-    <div className="w-full rounded-[1.2rem] border border-blue-200 lg:gap-[1.6rem] sm:gap-[0.8rem] lg:py-[2.4rem] lg:px-[3.2rem] sm:py-[1rem] sm:px-[2.4rem] flex items-center bg-blue-100">
+    <div className="w-full rounded-[1.2rem] border border-blue-200 lg:gap-[1.6rem] sm:gap-[0.8rem] lg:py-[2.4rem] lg:px-[3.2rem] sm:py-[1rem] sm:px-[2.4rem] flex items-center bg-blue-100 shadow-custom10">
       <Image src={info} alt="info" width={24} height={24} />
       <p className="font-semibold lg:text-[1.6rem] lg:leading-[2.6rem] sm:text-[1.3rem] sm:leading-[2.2rem] text-blue-300">
         확정하지 않은 견적이에요!

--- a/src/stories/MyQuoteReceivedToast.stories.tsx
+++ b/src/stories/MyQuoteReceivedToast.stories.tsx
@@ -1,0 +1,10 @@
+import MyQuoteReceivedToast from '@/components/toasts/MyQuoteReceivedToast';
+
+export default {
+  title: 'Components/Toasts/MyQuoteReceivedToast',
+  component: MyQuoteReceivedToast,
+};
+
+const Template = () => <MyQuoteReceivedToast />;
+
+export const Default = Template.bind({});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,6 +57,7 @@ const config: Config = {
         custom7: '0 2px 10px rgba(248, 248, 248, 0.1)',
         custom8: '0px 4px 8px rgba(0, 0, 0, 0.16)',
         custom9: '2px 2px 10px 0px rgba(220, 220, 220, 0.1), -2px -2px 10px 0px rgba(220, 220, 220, 0.1)',
+        custom10: '2px 2px 10px 0px rgba(46, 46, 46, 0.04), -2px -2px 10px 0px rgba(46, 46, 46, 0.04)',
         customBoth: '4px 4px 10px 0px rgba(225, 225, 225, 0.102), inset 6px 6px 10px 0px rgba(244, 244, 244, 0.2)',
         chipServiceShadow: '4px 4px 10px 0px rgba(230, 230, 230, 0.25)',
         chipAreaShadow: '4px 4px 10px 0px rgba(230, 230, 230, 0.161)',


### PR DESCRIPTION
## 이슈 번호

- close #139 

## 작업 사항
- [x] 확정견적이 아닐 때 토스트 컴포넌트 만들기
- [x] 페이지 연결하기

## 기타
### 받았던 견적 상세 페이지
- 들어오는 데이터에 따라 "확정 견적" 칩 or X

### 기사님 상세 페이지
- 찜하기, 지정 견적 요청 등 회원 비회원 페이지 기능 나누기
- [review 부분] 피그마에서 유저 name에 별표로 이름을 가려주는 부분이 있는데, 나중에 api 연결하고 완성되면 어떤 식으로 처리해줄지 상의해보면 좋을 것 같습니다
- pagination 기능은 백엔드 API 연결 후 확인 가능 (현재 불가)

### 상세 페이지 공통
- get Data API 연결하기
- 공유하기 기능 만들기 (링크, 카카오톡, 페이스북)
- ButtonClient API 연결하기