### PR TITLE
Jest test code of calendar card

### DIFF
--- a/src/components/cards/CalendarCard.tsx
+++ b/src/components/cards/CalendarCard.tsx
@@ -23,20 +23,24 @@ export default function CalendarCard({ setMovingDate, setIsMovingDate, initialMo
 
   const handleDateClick = (day: Day) => {
     const selected = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), day.date);
-
+    selected.setHours(0, 0, 0, 0);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
     if (!day.isCurrentMonth || selected < today) {
       return;
     }
-
     setSelectedDate(selected);
   };
 
   const handleSelectComplte = () => {
-    setMovingDate(selectedDate);
-    setIsMovingDate(true);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    if (selectedDate >= today) {
+      setMovingDate(selectedDate);
+      setIsMovingDate(true);
+    }
   };
 
   const daysInMonth = getDaysInMonth(currentMonth);

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import CalendarCard from '@/components/cards/CalendarCard';
 import { CalendarCardProps } from '@/interfaces/Card/CalendarCardInterface';
@@ -31,7 +31,7 @@ jest.mock('@/components/common/headless/Button', () => {
 describe('Calendar comp', () => {
   const mockSetMovingDate = jest.fn();
   const mockSetIsMovingDate = jest.fn();
-  const initialMovingDate = new Date('2024-01-23');
+  const initialMovingDate = new Date('2025-01-23');
 
   const defaultProps: CalendarCardProps = {
     setMovingDate: mockSetMovingDate,
@@ -42,7 +42,7 @@ describe('Calendar comp', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2024-01-23'));
+    jest.setSystemTime(new Date('2025-01-23'));
   });
 
   afterEach(() => {
@@ -52,7 +52,25 @@ describe('Calendar comp', () => {
   it('render CalendarCard', () => {
     render(<CalendarCard {...defaultProps} />);
 
-    expect(screen.getByText('2024.01')).toBeInTheDocument();
+    expect(screen.getByText('2025.01')).toBeInTheDocument();
     expect(screen.getByText('선택완료')).toBeInTheDocument();
+  });
+
+  it('move to the previous month', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    const prevBtn = screen.getByAltText('이전 달');
+    fireEvent.click(prevBtn);
+
+    expect(screen.getByText('2024.12')).toBeInTheDocument();
+  });
+
+  it('move to the next month', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    const nextBtn = screen.getByAltText('다음 달');
+    fireEvent.click(nextBtn);
+
+    expect(screen.getByText('2025.02')).toBeInTheDocument();
   });
 });

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -99,4 +99,13 @@ describe('Calendar comp', () => {
 
     expect(mockSetMovingDate).not.toHaveBeenCalledWith(expect.any(Date));
   });
+
+  it('display weekdays', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    weekdays.forEach(day => {
+      expect(screen.getByText(day)).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -108,4 +108,11 @@ describe('Calendar comp', () => {
       expect(screen.getByText(day)).toBeInTheDocument();
     });
   });
+
+  it('disable complete button as no date', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    const selectBtn = screen.getByTestId('calendar-button');
+    expect(selectBtn).toHaveAttribute('disabled');
+  });
 });

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+
+// Mocking ButtonWrapper
+jest.mock('@/components/common/headless/Button', () => {
+  const MockButtonWrapper = ({ children, id }: { children: ReactNode; id: string }) => <div data-testid={id}>{children}</div>;
+
+  MockButtonWrapper.Button = ({
+    children,
+    onClick,
+    disabled,
+    className,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    className?: string;
+  }) => (
+    <button data-testid="calendar-button" onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </button>
+  );
+
+  return {
+    ButtonWrapper: MockButtonWrapper,
+  };
+});

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -73,4 +73,17 @@ describe('Calendar comp', () => {
 
     expect(screen.getByText('2025.02')).toBeInTheDocument();
   });
+
+  it('select a date', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    const dateElement = screen.getByText('20');
+    fireEvent.click(dateElement);
+
+    const selectBtn = screen.getByText('선택완료');
+    fireEvent.click(selectBtn);
+
+    expect(mockSetIsMovingDate).toHaveBeenCalledWith(expect.any(Date));
+    expect(mockSetIsMovingDate).toHaveBeenCalledWith(true);
+  });
 });

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -86,4 +86,17 @@ describe('Calendar comp', () => {
     expect(mockSetIsMovingDate).toHaveBeenCalledWith(expect.any(Date));
     expect(mockSetIsMovingDate).toHaveBeenCalledWith(true);
   });
+
+  it('now allow selecting past date', () => {
+    jest.setSystemTime(new Date('2025-01-15'));
+    render(<CalendarCard {...defaultProps} />);
+
+    const pastDate = screen.getByText('1');
+    fireEvent.click(pastDate);
+
+    const selectBtn = screen.getByText('선택완료');
+    fireEvent.click(selectBtn);
+
+    expect(mockSetMovingDate).not.toHaveBeenCalledWith(expect.any(Date));
+  });
 });

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -1,4 +1,7 @@
+import { render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
+import CalendarCard from '@/components/cards/CalendarCard';
+import { CalendarCardProps } from '@/interfaces/Card/CalendarCardInterface';
 
 // Mocking ButtonWrapper
 jest.mock('@/components/common/headless/Button', () => {
@@ -23,4 +26,33 @@ jest.mock('@/components/common/headless/Button', () => {
   return {
     ButtonWrapper: MockButtonWrapper,
   };
+});
+
+describe('Calendar comp', () => {
+  const mockSetMovingDate = jest.fn();
+  const mockSetIsMovingDate = jest.fn();
+  const initialMovingDate = new Date('2024-01-23');
+
+  const defaultProps: CalendarCardProps = {
+    setMovingDate: mockSetMovingDate,
+    setIsMovingDate: mockSetIsMovingDate,
+    initialMovingDate,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-23'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('render CalendarCard', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    expect(screen.getByText('2024.01')).toBeInTheDocument();
+    expect(screen.getByText('선택완료')).toBeInTheDocument();
+  });
 });

--- a/tests/components/cards/CalendarCard.test.tsx
+++ b/tests/components/cards/CalendarCard.test.tsx
@@ -1,16 +1,17 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
+import * as FormatUtils from '@/utils/Format';
 import CalendarCard from '@/components/cards/CalendarCard';
 import { CalendarCardProps } from '@/interfaces/Card/CalendarCardInterface';
 
-// Mocking ButtonWrapper
+// Mock the ButtonWrapper completely
 jest.mock('@/components/common/headless/Button', () => {
   const MockButtonWrapper = ({ children, id }: { children: ReactNode; id: string }) => <div data-testid={id}>{children}</div>;
 
   MockButtonWrapper.Button = ({
     children,
     onClick,
-    disabled,
+    disabled = false,
     className,
   }: {
     children: ReactNode;
@@ -18,7 +19,7 @@ jest.mock('@/components/common/headless/Button', () => {
     disabled?: boolean;
     className?: string;
   }) => (
-    <button data-testid="calendar-button" onClick={onClick} disabled={disabled} className={className}>
+    <button data-testid="calendar-button" onClick={disabled ? undefined : onClick} disabled={disabled} className={className}>
       {children}
     </button>
   );
@@ -28,7 +29,12 @@ jest.mock('@/components/common/headless/Button', () => {
   };
 });
 
-describe('Calendar comp', () => {
+// Mock getDaysInMonth
+jest.mock('@/utils/Format', () => ({
+  getDaysInMonth: jest.fn(),
+}));
+
+describe('CalendarCard', () => {
   const mockSetMovingDate = jest.fn();
   const mockSetIsMovingDate = jest.fn();
   const initialMovingDate = new Date('2025-01-23');
@@ -39,80 +45,105 @@ describe('Calendar comp', () => {
     initialMovingDate,
   };
 
+  const createMockDays = (currentMonth = true) => [
+    { date: 29, isCurrentMonth: false },
+    { date: 30, isCurrentMonth: false },
+    { date: 31, isCurrentMonth: false },
+
+    { date: 1, isCurrentMonth: currentMonth },
+    { date: 2, isCurrentMonth: currentMonth },
+    { date: 16, isCurrentMonth: currentMonth },
+    { date: 17, isCurrentMonth: currentMonth },
+    { date: 18, isCurrentMonth: currentMonth },
+    { date: 23, isCurrentMonth: currentMonth },
+
+    { date: 1, isCurrentMonth: false },
+    { date: 2, isCurrentMonth: false },
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-23'));
+    jest.setSystemTime(new Date('2025-01-15'));
+
+    // Default mock implementation
+    (FormatUtils.getDaysInMonth as jest.Mock).mockReturnValue(createMockDays());
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it('render CalendarCard', () => {
+  it('renders the calendar with correct month and year', () => {
     render(<CalendarCard {...defaultProps} />);
-
     expect(screen.getByText('2025.01')).toBeInTheDocument();
-    expect(screen.getByText('선택완료')).toBeInTheDocument();
   });
 
-  it('move to the previous month', () => {
+  it('navigates to previous month', () => {
     render(<CalendarCard {...defaultProps} />);
+    const prevButton = screen.getByAltText('이전 달');
 
-    const prevBtn = screen.getByAltText('이전 달');
-    fireEvent.click(prevBtn);
+    (FormatUtils.getDaysInMonth as jest.Mock).mockReturnValueOnce(createMockDays(false));
 
+    fireEvent.click(prevButton);
     expect(screen.getByText('2024.12')).toBeInTheDocument();
   });
 
-  it('move to the next month', () => {
+  it('navigates to next month', () => {
     render(<CalendarCard {...defaultProps} />);
+    const nextButton = screen.getByAltText('다음 달');
 
-    const nextBtn = screen.getByAltText('다음 달');
-    fireEvent.click(nextBtn);
+    (FormatUtils.getDaysInMonth as jest.Mock).mockReturnValueOnce(createMockDays(false));
 
+    fireEvent.click(nextButton);
     expect(screen.getByText('2025.02')).toBeInTheDocument();
   });
 
-  it('select a date', () => {
+  it('selects initial date by default', () => {
     render(<CalendarCard {...defaultProps} />);
 
-    const dateElement = screen.getByText('20');
-    fireEvent.click(dateElement);
+    const initialDateElement = screen.getByText('23');
 
-    const selectBtn = screen.getByText('선택완료');
-    fireEvent.click(selectBtn);
+    expect(initialDateElement.classList.contains('bg-blue-300')).toBeTruthy();
+  });
 
-    expect(mockSetIsMovingDate).toHaveBeenCalledWith(expect.any(Date));
+  it('prevents selecting past dates', () => {
+    const initialMovingDate = new Date('2025-01-01');
+    const previousProps: CalendarCardProps = {
+      ...defaultProps,
+      initialMovingDate,
+    };
+    render(<CalendarCard {...previousProps} />);
+
+    const pastDateElements = screen.getAllByText('1');
+    fireEvent.click(pastDateElements[0]);
+
+    const completeButton = screen.getByText('선택완료');
+    fireEvent.click(completeButton);
+
+    expect(mockSetMovingDate).not.toHaveBeenCalled();
+    expect(mockSetIsMovingDate).not.toHaveBeenCalled();
+  });
+
+  it('allows selecting future dates', () => {
+    render(<CalendarCard {...defaultProps} />);
+
+    const futureDateElement = screen.getByText('16');
+    fireEvent.click(futureDateElement);
+
+    const completeButton = screen.getByText('선택완료');
+    fireEvent.click(completeButton);
+
+    expect(mockSetMovingDate).toHaveBeenCalledWith(expect.any(Date));
     expect(mockSetIsMovingDate).toHaveBeenCalledWith(true);
   });
 
-  it('now allow selecting past date', () => {
-    jest.setSystemTime(new Date('2025-01-15'));
-    render(<CalendarCard {...defaultProps} />);
-
-    const pastDate = screen.getByText('1');
-    fireEvent.click(pastDate);
-
-    const selectBtn = screen.getByText('선택완료');
-    fireEvent.click(selectBtn);
-
-    expect(mockSetMovingDate).not.toHaveBeenCalledWith(expect.any(Date));
-  });
-
-  it('display weekdays', () => {
+  it('displays all weekdays', () => {
     render(<CalendarCard {...defaultProps} />);
 
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
     weekdays.forEach(day => {
       expect(screen.getByText(day)).toBeInTheDocument();
     });
-  });
-
-  it('disable complete button as no date', () => {
-    render(<CalendarCard {...defaultProps} />);
-
-    const selectBtn = screen.getByTestId('calendar-button');
-    expect(selectBtn).toHaveAttribute('disabled');
   });
 });

--- a/tests/components/modal/AddressModal.test.tsx
+++ b/tests/components/modal/AddressModal.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import DaumPostcode, { type Address } from 'react-daum-postcode';
+import { type Address } from 'react-daum-postcode';
 import AddressModal from '@/components/modal/AddressModal';
-import type { AddressModalProps } from '@/interfaces/Modal/AddressModalInterface';
 
 // Mocking ModalWrapper
 jest.mock('@/components/common/headless/Modal', () => {


### PR DESCRIPTION
## 이슈 번호

- close #200 

## 작업 사항

- Render calendar
- Navigate before & next month
- Select date
- Prevent selecting past date
- Allow selecting future date
- Display all weekdays

## 기타

![image](https://github.com/user-attachments/assets/d5122c73-2a5d-4801-96bd-3ba50e919919)

